### PR TITLE
Add region-specific YouTube search batching

### DIFF
--- a/countries.py
+++ b/countries.py
@@ -1,3 +1,6 @@
+import pycountry
+
+
 SHORT_COUNTRIES = [
     "Afghanistan",
     "Albania",
@@ -249,3 +252,30 @@ COUNTRIES = [
     "Zambia",
     "Zimbabwe"
 ]
+
+# Mapping from country names to ISO-3166 alpha-2 region codes
+# Generated using the ``pycountry`` package with manual fallbacks for
+# names that do not have direct matches.
+COUNTRY_CODES = {}
+for _name in COUNTRIES:
+    try:
+        COUNTRY_CODES[_name] = pycountry.countries.lookup(_name).alpha_2
+    except LookupError:
+        pass
+
+COUNTRY_CODES.update({
+    "Cape Verde": "CV",
+    "Cote D'ivoire": "CI",
+    "East Timor": "TL",
+    "Kazakstan": "KZ",
+    "Kosovo": "XK",
+    "Libyan Arab Jamahiriya": "LY",
+    "Macau": "MO",
+    "Macedonia, The Former Yugoslav Republic Of": "MK",
+    "Netherlands Antilles": "AN",
+    "Palestinian Territory, Occupied": "PS",
+    "Reunion": "RE",
+    "Saint Helena": "SH",
+    "Swaziland": "SZ",
+    "Turkey": "TR",
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ simplejson==3.8.2
 six==1.10.0
 uritemplate==0.6
 Werkzeug==0.11.10
+pycountry

--- a/youtube.py
+++ b/youtube.py
@@ -3,6 +3,7 @@ import countries
 import time
 from apiclient.discovery import build
 from apiclient.errors import HttpError
+from apiclient.http import BatchHttpRequest
 from oauth2client.tools import argparser
 
 YOUTUBE_API_SERVICE_NAME = "youtube"
@@ -20,27 +21,55 @@ country_pages = [
 num_pages = len(country_pages)
 
 
-def search(query, max_results=5):
-    youtube = build(YOUTUBE_API_SERVICE_NAME,
-                    YOUTUBE_API_VERSION,
-                    developerKey=DEVELOPER_KEY)
+def search(query, max_results=5, region_code=None, youtube_service=None, execute=True):
+    youtube = youtube_service or build(YOUTUBE_API_SERVICE_NAME,
+                                       YOUTUBE_API_VERSION,
+                                       developerKey=DEVELOPER_KEY)
 
-    return youtube.search().list(
+    request = youtube.search().list(
         q=query,
         part="id,snippet",
         type='video',
         order='rating',
         maxResults=max_results,
-    ).execute()
+        regionCode=region_code,
+    )
+    return request.execute() if execute else request
 
 
 def search_countries(query, page_num):
-    page = country_pages[page_num] if page_num < num_pages \
-                else country_pages[-1]
-    results = []
+    page = country_pages[page_num] if page_num < num_pages else country_pages[-1]
+    youtube = build(YOUTUBE_API_SERVICE_NAME,
+                    YOUTUBE_API_VERSION,
+                    developerKey=DEVELOPER_KEY)
+
+    results_by_country = {}
+
+    def _callback(request_id, response, exception):
+        results_by_country[request_id] = {
+            'country': request_id,
+            'query': query,
+            'results': None if exception else response
+        }
+
+    batch = BatchHttpRequest(callback=_callback)
+    has_requests = False
+
     for country in page:
-        youtube_query = "{} {}".format(query, country)
-        results.append({'country': country,
-                        'query': youtube_query,
-                        'results': search(youtube_query)})
-    return results
+        region_code = countries.COUNTRY_CODES.get(country)
+        if not region_code:
+            results_by_country[country] = {'country': country,
+                                           'query': query,
+                                           'results': None}
+            continue
+        req = search(query,
+                     region_code=region_code,
+                     youtube_service=youtube,
+                     execute=False)
+        batch.add(req, request_id=country)
+        has_requests = True
+
+    if has_requests:
+        batch.execute()
+
+    return [results_by_country[country] for country in page]


### PR DESCRIPTION
## Summary
- map country names to ISO-3166 region codes using `pycountry`
- allow search to set YouTube `regionCode`
- batch region-specific searches with `BatchHttpRequest`

## Testing
- `python -m py_compile worldtube/countries.py worldtube/youtube.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f7f1954883339c9df3c6c4b8b435